### PR TITLE
Fix the issue about losing clone project process and remove option.

### DIFF
--- a/.github/workflows/ci-cd-master.yml
+++ b/.github/workflows/ci-cd-master.yml
@@ -319,6 +319,9 @@ jobs:
     needs: codecov_finish
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -292,5 +292,5 @@ jobs:
         run: coverage combine .coverage.*
 
       - name: Display testing coverage of project code
-        run: coverage report -m
+        run: coverage report
 


### PR DESCRIPTION
⚒🛠💣 Fix issues

1. For master, add new action about cloning project code in job 'build_and_push_to_pypi'.
2. For develop, remove the option 'm' in action 'coverage report'.

